### PR TITLE
add on.workflow_dispatch: for running the github workflow directly

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,6 +2,7 @@
 name: Release Charts
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master


### PR DESCRIPTION
This just add workflow_dispatch so that I can test deploying the helm chart.