### PR TITLE
Fix/dont set replicas in pod if hpa enabled

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -80,7 +80,7 @@ jobs:
 
           # test the helm chart with horizontal pod autoscaling enabled
           - name: Horizontal Pod Autoscaling Enabled
-            helm_args: '--helm-extra-set-args "--set=hpa.enabled=true --set=hpa.minPods=1 --set=hpa.maxPods=3 --set=hpa.targetCPUUtilizationPercentage=75"'
+            helm_args: '--helm-extra-set-args "--set=hpa.enabled=true --set=hpa.minPods=2 --set=hpa.maxPods=3 --set=hpa.targetCPUUtilizationPercentage=75"'
 
     steps:
       - name: Checkout

--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 5.3.0
+version: 5.3.1
 appVersion: 29.0.4
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -203,7 +203,7 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `startupProbe.timeoutSeconds`                              | When the probe times out                                                                            | `5`                        |
 | `startupProbe.failureThreshold`                            | Minimum consecutive failures for the probe                                                          | `30`                       |
 | `startupProbe.successThreshold`                            | Minimum consecutive successes for the probe                                                         | `1`                        |
-| `hpa.enabled`                                              | Boolean to create a HorizontalPodAutoscaler                                                         | `false`                    |
+| `hpa.enabled`                                              | Boolean to create a HorizontalPodAutoscaler. If set to `true`, ignores `replicaCount`.              | `false`                    |
 | `hpa.cputhreshold`                                         | CPU threshold percent for the HorizontalPodAutoscale                                                | `60`                       |
 | `hpa.minPods`                                              | Min. pods for the Nextcloud HorizontalPodAutoscaler                                                 | `1`                        |
 | `hpa.maxPods`                                              | Max. pods for the Nextcloud HorizontalPodAutoscaler                                                 | `10`                       |

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -17,7 +17,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if not .Values.hpa.enabled }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   strategy:
     {{- toYaml .Values.nextcloud.strategy | nindent 4 }}
   selector:


### PR DESCRIPTION
## Description of the change

this is just meant to allow proper ci testing before the merge to the upstream repo.

Going to try using on label as mentioned here:
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request